### PR TITLE
Fix: Correct NPV discounting for students starting mid-simulation

### DIFF
--- a/impact_isa_model.py
+++ b/impact_isa_model.py
@@ -516,65 +516,65 @@ def calculate_student_statistics(student: Student, num_years: int, remittance_ra
     
     Parameters:
     - student: Student object
-    - num_years: Number of years in simulation
+    - num_years: Number of years in simulation (this refers to the student's specific simulation duration)
     - remittance_rate: Percentage of income sent as remittances
     - impact_params: Parameters for impact calculation
     
     Returns:
     - Dictionary of student statistics
     """
-    # Calculate lifetime earnings
+    # Calculate lifetime earnings (undiscounted sum)
     lifetime_earnings = np.sum(student.earnings)
     
-    # Calculate real (present value) earnings
-    discount_factors = np.array([(1 / (1 + impact_params.discount_rate)) ** t for t in range(num_years)])
-    lifetime_real_earnings = np.sum(student.earnings[:len(discount_factors)] * discount_factors[:len(student.earnings)])
+    # Calculate real (present value) earnings, discounted to absolute simulation year 0
+    if len(student.earnings) == 0:
+        lifetime_real_earnings = 0.0
+    else:
+        # 't' is the index relative to the start of the student's earnings array.
+        # Earning at student.earnings[t] occurred in absolute simulation year 'student.start_year + t'.
+        discount_factors_for_pv_earnings = np.array([(1 / (1 + impact_params.discount_rate)) ** (student.start_year + t) for t in range(len(student.earnings))])
+        lifetime_real_earnings = np.sum(student.earnings * discount_factors_for_pv_earnings)
     
-    # Calculate counterfactual lifetime earnings
-    counterfactual_lifetime_earnings = np.sum(student.counterfactual_earnings)
-    
-    # Calculate remittances
+    # Calculate counterfactual lifetime earnings (undiscounted sum)
+    counterfactual_lifetime_earnings = np.sum(student.counterfactual_earnings) 
+
+    # Calculate remittances (based on undiscounted earnings)
     lifetime_remittances = lifetime_earnings * remittance_rate
     counterfactual_remittances = counterfactual_lifetime_earnings * impact_params.counterfactual.remittance_rate
     
-    # Calculate yearly utilities with proper discounting
+    # Calculate yearly utilities with proper discounting to absolute simulation year 0
     yearly_utilities = []
     yearly_counterfactual_utilities = []
     
-    for year in range(len(student.earnings)):
-        if year < len(student.earnings):
-            # Apply discount factor for this year
-            discount_factor = (1 / (1 + impact_params.discount_rate)) ** year if year < len(discount_factors) else 0
-            
-            # Calculate utilities for this year
-            year_utils = calculate_total_utility(
-                student.earnings[year],
-                student.counterfactual_earnings[year],
-                remittance_rate,
-                impact_params.moral_weight
-            )
-            
-            # Apply discount factor to all utility components
-            for key in year_utils:
-                year_utils[key] *= discount_factor
-                
-            yearly_utilities.append(year_utils)
-            
-            # Counterfactual utilities (only remittances from base earnings)
-            counterfactual_utils = calculate_total_utility(
-                student.counterfactual_earnings[year],
-                0,  # No counterfactual to counterfactual
-                impact_params.counterfactual.remittance_rate,
-                impact_params.moral_weight
-            )
-            
-            # Apply discount factor to counterfactual utilities
-            for key in counterfactual_utils:
-                counterfactual_utils[key] *= discount_factor
-                
-            yearly_counterfactual_utilities.append(counterfactual_utils)
+    for idx_relative_to_student_earnings in range(len(student.earnings)):
+        absolute_simulation_year = student.start_year + idx_relative_to_student_earnings
+        discount_factor = (1 / (1 + impact_params.discount_rate)) ** absolute_simulation_year
+        
+        # Calculate per-year undiscounted utilities
+        year_utils = calculate_total_utility(
+            student.earnings[idx_relative_to_student_earnings],
+            student.counterfactual_earnings[idx_relative_to_student_earnings],
+            remittance_rate,
+            impact_params.moral_weight
+        )
+        # Discount and store
+        for key in year_utils:
+            year_utils[key] *= discount_factor
+        yearly_utilities.append(year_utils)
+        
+        # Calculate per-year undiscounted counterfactual utilities
+        counterfactual_utils = calculate_total_utility(
+            student.counterfactual_earnings[idx_relative_to_student_earnings],
+            0,  # No counterfactual to counterfactual
+            impact_params.counterfactual.remittance_rate,
+            impact_params.moral_weight
+        )
+        # Discount and store
+        for key in counterfactual_utils:
+            counterfactual_utils[key] *= discount_factor
+        yearly_counterfactual_utilities.append(counterfactual_utils)
     
-    # Sum utilities over time
+    # Sum discounted yearly utilities to get total present values
     total_student_utility = sum(u['student_utility'] for u in yearly_utilities)
     total_remittance_utility = sum(u['remittance_utility'] for u in yearly_utilities)
     total_utility = sum(u['total_utility'] for u in yearly_utilities)
@@ -583,66 +583,59 @@ def calculate_student_statistics(student: Student, num_years: int, remittance_ra
     counterfactual_remittance_utility = sum(u['remittance_utility'] for u in yearly_counterfactual_utilities)
     counterfactual_total_utility = sum(u['total_utility'] for u in yearly_counterfactual_utilities)
     
-    # Calculate utility gains
     utility_gains = {
         'student_utility_gain': total_student_utility - counterfactual_student_utility,
         'remittance_utility_gain': total_remittance_utility - counterfactual_remittance_utility,
         'total_utility_gain': total_utility - counterfactual_total_utility
     }
     
-    # Calculate employment statistics
     years_employed = np.sum(student.employment_history)
+    total_isa_payments = np.sum(student.payments) # Undiscounted sum
     
-    # Calculate ISA payments
-    total_isa_payments = np.sum(student.payments)
-    
-    # Calculate PPP-adjusted earnings gain
+    # PPP-adjusted earnings gain (based on undiscounted lifetime earnings gain)
     ppp_adjusted_earnings_gain = (lifetime_earnings - counterfactual_lifetime_earnings) * impact_params.ppp_multiplier
     
-    # Calculate health benefits using GiveWell's approach
-    # Life expectancy improvement from 62 to 81 years (19 years)
-    # Value of 40 units for this improvement, discounted at 5%
-    # This results in approximately 3 utils per student, which is a fraction of income utility (about 160)
-    health_utility = 3.0  # Fixed value based on GiveWell's approach
-    
-    # Calculate follow-the-leader migration effects
-    migration_utility = 0
+    # Health utility: Fixed value of 3.0 utils, discounted to PV from graduation time.
+    health_utility_pv = 0.0
+    if student.is_graduated:
+        # student.actual_years_to_complete is relative to the student's start.
+        year_of_health_benefit_realization = student.start_year + student.actual_years_to_complete
+        health_utility_pv = 3.0 * ((1 / (1 + impact_params.discount_rate)) ** year_of_health_benefit_realization)
+
+    # Migration utility (based on already discounted total_utility_gain)
+    migration_utility_pv = 0.0
     if student.is_graduated and not student.is_home:
-        # Calculate average utility gain for a successful migrant
-        avg_utility_gain = utility_gains['total_utility_gain']
-        # Each graduate influences impact_params.migration_influence_factor additional people
-        migration_utility = avg_utility_gain * impact_params.migration_influence_factor
+        migration_utility_pv = utility_gains['total_utility_gain'] * impact_params.migration_influence_factor # total_utility_gain is already PV
     
-    # Update total utility gains with new factors
-    utility_gains['health_utility_gain'] = health_utility
-    utility_gains['migration_influence_utility_gain'] = migration_utility
+    utility_gains['health_utility_gain'] = health_utility_pv 
+    utility_gains['migration_influence_utility_gain'] = migration_utility_pv 
     utility_gains['total_utility_gain_with_extras'] = (
         utility_gains['total_utility_gain'] + 
-        health_utility + 
-        migration_utility
+        health_utility_pv + 
+        migration_utility_pv
     )
     
     return {
         'degree_type': student.degree.name,
         'graduated': student.is_graduated,
         'dropped_out': not student.is_graduated,
-        'lifetime_earnings': lifetime_earnings,
-        'lifetime_real_earnings': lifetime_real_earnings,
-        'counterfactual_lifetime_earnings': counterfactual_lifetime_earnings,
-        'earnings_gain': lifetime_earnings - counterfactual_lifetime_earnings,
-        'ppp_adjusted_earnings_gain': ppp_adjusted_earnings_gain,
-        'lifetime_remittances': lifetime_remittances,
-        'counterfactual_remittances': counterfactual_remittances,
-        'remittance_gain': lifetime_remittances - counterfactual_remittances,
-        'utility_gains': utility_gains,
-        'health_utility': health_utility,
-        'migration_utility': migration_utility,
+        'lifetime_earnings': lifetime_earnings,  # Undiscounted
+        'lifetime_real_earnings': lifetime_real_earnings,  # Discounted to year 0
+        'counterfactual_lifetime_earnings': counterfactual_lifetime_earnings,  # Undiscounted
+        'earnings_gain': lifetime_earnings - counterfactual_lifetime_earnings,  # Undiscounted
+        'ppp_adjusted_earnings_gain': ppp_adjusted_earnings_gain,  # Based on undiscounted gain
+        'lifetime_remittances': lifetime_remittances,  # Undiscounted
+        'counterfactual_remittances': counterfactual_remittances,  # Undiscounted
+        'remittance_gain': lifetime_remittances - counterfactual_remittances,  # Undiscounted
+        'utility_gains': utility_gains,  # All components are PVs
+        'health_utility': health_utility_pv,  # PV of fixed health utility
+        'migration_utility': migration_utility_pv,  # PV of migration utility
         'years_employed': years_employed,
-        'total_isa_payments': total_isa_payments,
+        'total_isa_payments': total_isa_payments,  # Undiscounted sum
         'years_paid_isa': student.years_paid,
         'hit_payment_cap': student.hit_cap,
-        'yearly_utilities': yearly_utilities,
-        'yearly_counterfactual_utilities': yearly_counterfactual_utilities
+        'yearly_utilities': yearly_utilities,  # List of dicts, values already discounted to year 0
+        'yearly_counterfactual_utilities': yearly_counterfactual_utilities  # List of dicts, values already discounted to year 0
     }
 
 def simulate_impact(


### PR DESCRIPTION
The `calculate_student_statistics` function in `impact_isa_model.py` was previously discounting student earnings and utilities back to the student's individual start year, not to the absolute start of the simulation (Year 0). This resulted in an incorrect NPV for the overall impact when students started in years > 0.

This commit corrects the discounting logic by incorporating the `student.start_year` into the exponent of the discount factor calculation for:
- `lifetime_real_earnings`
- `yearly_utilities` (and `yearly_counterfactual_utilities`)
- `health_utility_pv` (present value of the fixed health utility benefit)
- `migration_utility_pv` (which is based on already discounted utility gains)

All present values are now correctly discounted to the absolute Year 0 of the simulation.

Note on Caching:
The web application `simulation_dashboard.py` uses a caching mechanism (writing to `.parquet` files in the `cache/` directory). The changes in this commit will make any existing cached data stale. If `precompute_percentile_scenarios()` is run (e.g., on a fresh deployment or if the `SKIP_PRECOMPUTATION` environment variable is not set to true), it will regenerate the cache files using the corrected NPV logic. Otherwise, you should manually clear the `cache/` directory to ensure all displayed data reflects this correction.